### PR TITLE
docs: Fix typo in variable name Update faq.md

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -115,7 +115,7 @@ There are several ways to contribute to the ai16z project:
 
 - **Participate in community discussions**: Share your memecoin insights, propose new ideas, and engage with other community members.
 - **Contribute to the development of the ai16z platform**: https://github.com/orgs/ai16z/projects/1/views/3
-- **Help build the ai16z ecosystem**: Create applicatoins / tools, resources, and memes. Give feedback, and spread the word
+- **Help build the ai16z ecosystem**: Create applications / tools, resources, and memes. Give feedback, and spread the word
 
 **Other questions:**
 


### PR DESCRIPTION
# Risks

Low

## What does this PR do?

<img width="955" alt="Снимок экрана 2025-01-27 в 11 23 51" src="https://github.com/user-attachments/assets/f79fb9ae-33a3-4b96-8141-f7faf0d82183" />

I noticed a typo in the variable name where "applicatoins" was misspelled.
I've corrected it to "applications" to ensure consistency and accuracy in the codebase. 

## What kind of change is this?

Features (non-breaking change which adds functionality)

## Discord username

famouswizard
