### PR TITLE
fix: fix incorrect pnpm clean command in start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,7 +13,7 @@ cd "$(dirname "$0")"/..
 
 # clean cache
 echo -e "\033[1mCleaning cache...\033[0m"
-if ! pnpm clean; then
+if ! pnpm store prune; then
     echo -e "\033[1;31mFailed to clean cache\033[0m"
     exit 1
 fi


### PR DESCRIPTION
## What does this PR do?

`pnpm clean` was being used, but this command doesn’t actually exist in pnpm.
The closest equivalent for clearing the cache is `pnpm store prune`, so I’ve updated the script accordingly. 