### PR TITLE
refactor: safer cleanup logic with separate `find` commands

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -4,8 +4,8 @@
 cd "$(dirname "$0")"/..
 echo "Cleanup started."
 # Find and remove node_modules directories, dist directories, and pnpm-lock.yaml files
-find . -type d -name "node_modules" -exec rm -rf {} + \
-    -o -type d -name "dist" -exec rm -rf {} + \
-    -o -type f -name "pnpm-lock.yaml" -exec rm -f {} +
+find . -type d -name "node_modules" -exec rm -rf {} +
+find . -type d -name "dist" -exec rm -rf {} +
+find . -type f -name "pnpm-lock.yaml" -exec rm -f {} +
 
 echo "Cleanup completed."


### PR DESCRIPTION
# Background

## What does this PR do?

Refactored the script to avoid `-o` logic in `find` with `-exec`, which could cause missed matches.
Each cleanup now runs in isolation for clarity and reliability.
